### PR TITLE
Add progress bar and label marker controls

### DIFF
--- a/audio_labeling_project/audio_processor/spectrogram_generator.py
+++ b/audio_labeling_project/audio_processor/spectrogram_generator.py
@@ -50,3 +50,25 @@ def draw_playback_line(pixmap, playback_position, total_frames):
     painter.drawLine(x, 0, x, pixmap.height())
     painter.end()
     return pixmap_with_line
+
+
+def draw_annotations(pixmap, annotations, total_frames, samplerate):
+    """Draw stored annotation regions onto *pixmap*."""
+    if pixmap.isNull() or not annotations:
+        return pixmap
+
+    annotated = QPixmap(pixmap)
+    painter = QPainter(annotated)
+    painter.setRenderHint(QPainter.RenderHint.Antialiasing)
+    pen = QPen(Qt.GlobalColor.green)
+    pen.setWidth(2)
+    painter.setPen(pen)
+
+    for start, end, _ in annotations:
+        start_x = int((start * samplerate / total_frames) * pixmap.width())
+        end_x = int((end * samplerate / total_frames) * pixmap.width())
+        painter.drawLine(start_x, 0, start_x, pixmap.height())
+        painter.drawLine(end_x, 0, end_x, pixmap.height())
+
+    painter.end()
+    return annotated


### PR DESCRIPTION
## Summary
- show a progress bar while loading audio files
- allow marking start and end of a segment with dedicated buttons
- render stored annotations on the spectrogram

## Testing
- `python -m py_compile audio_labeling_project/ui/main_window.py`
- `python -m py_compile audio_labeling_project/audio_processor/spectrogram_generator.py`
- `python -m py_compile audio_labeling_project/audio_processor/cutter.py`
- `python -m py_compile audio_labeling_project/utils/*.py`
- `python -m py_compile audio_labeling_project/main.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68628e8b5ec8832a8ec576edcde6eac2