### PR TITLE
Enhance UX with metadata, shortcuts and popup

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,11 @@ python audio_labeling_project/main.py
 - Modo de etiquetado: permite seleccionar segmentos en el espectrograma y asignarles una categoría.
 - Guardado de los segmentos etiquetados como archivos individuales en la carpeta `labeled_cuts/`, organizados por categoría.
 - Registro automático de los audios ya etiquetados para evitar reprocesarlos.
+- Visualización de metadatos del archivo cargado (frecuencia de muestreo,
+  duración y tamaño).
+- Confirmación visual breve tras guardar los cortes.
+- Atajos de teclado configurables para reproducir/pausar, marcar inicio,
+  marcar fin y avanzar al siguiente audio.
 
 ### Categorías disponibles
 

--- a/audio_labeling_project/config.py
+++ b/audio_labeling_project/config.py
@@ -10,4 +10,10 @@ CONFIG = {
         "Human_presence",
         "Drumming",
     ],
+    "SHORTCUTS": {
+        "play_pause": "Space",
+        "mark_start": "S",
+        "mark_end": "E",
+        "next_audio": "N",
+    },
 }


### PR DESCRIPTION
## Summary
- show metadata (sample rate, duration, size) for loaded audio files
- display confirmation popup after saving cuts
- make keyboard shortcuts configurable and show them in UI
- document new features in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_6862ade47b24832aaec428e60ba55ab8