### PR TITLE
Add memory management tab and clear labels

### DIFF
--- a/audio_labeling_project/config.py
+++ b/audio_labeling_project/config.py
@@ -15,5 +15,7 @@ CONFIG = {
         "mark_start": "S",
         "mark_end": "E",
         "next_audio": "N",
+        "clear_labels": "C",
+        "save_labels": "Ctrl+S",
     },
 }

--- a/audio_labeling_project/utils/logger.py
+++ b/audio_labeling_project/utils/logger.py
@@ -32,3 +32,15 @@ def log_labeled_audio(audio_path, labeled_audios_dict):
     os.makedirs(os.path.dirname(log_path), exist_ok=True)
     with open(log_path, "w") as f:
         json.dump(labeled_audios_dict, f, indent=4)
+
+
+def remove_labeled_audio(audio_path, labeled_audios_dict):
+    """Remove an entry from the labeled audios log."""
+    if audio_path in labeled_audios_dict:
+        del labeled_audios_dict[audio_path]
+        log_path = CONFIG["LOG_FILE"]
+        os.makedirs(os.path.dirname(log_path), exist_ok=True)
+        with open(log_path, "w") as f:
+            json.dump(labeled_audios_dict, f, indent=4)
+        return True
+    return False


### PR DESCRIPTION
## Summary
- include keyboard shortcuts for save and clear actions in config
- introduce memory manager tab with table listing processed files
- allow deleting entries from memlog via the new tab
- add `Clear Labels` button and shortcut
- refresh memory table after saving

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_6862b5901b7c832a84eff65759deae23