### PR TITLE
Add search and file panel features

### DIFF
--- a/audio_labeling_project/config.py
+++ b/audio_labeling_project/config.py
@@ -2,6 +2,7 @@ CONFIG = {
     "AUDIO_EXTENSIONS": [".wav", ".mp3"],
     "SAMPLE_RATE": 44100,
     "LOG_FILE": "memlog/log.json",
+    "LABELS_FILE": "memlog/labels.json",
     "CATEGORIES": [
         "Hoot",
         "Climax",

--- a/audio_labeling_project/utils/logger.py
+++ b/audio_labeling_project/utils/logger.py
@@ -3,6 +3,37 @@ import os
 from config import CONFIG
 
 
+def load_labels_data():
+    """Load stored label details for audios."""
+    path = CONFIG.get("LABELS_FILE", "memlog/labels.json")
+    if os.path.exists(path):
+        with open(path, "r") as f:
+            return json.load(f)
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    return {}
+
+
+def save_labels_for_audio(audio_path, annotations, labels_data):
+    """Save annotation list for an audio file."""
+    labels_data[audio_path] = annotations
+    path = CONFIG.get("LABELS_FILE", "memlog/labels.json")
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w") as f:
+        json.dump(labels_data, f, indent=4)
+
+
+def remove_labels_for_audio(audio_path, labels_data):
+    """Remove saved annotations for an audio file."""
+    if audio_path in labels_data:
+        del labels_data[audio_path]
+        path = CONFIG.get("LABELS_FILE", "memlog/labels.json")
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, "w") as f:
+            json.dump(labels_data, f, indent=4)
+        return True
+    return False
+
+
 def load_labeled_audios_log():
     """
     Loads the log of already labeled audio files.
@@ -34,13 +65,18 @@ def log_labeled_audio(audio_path, labeled_audios_dict):
         json.dump(labeled_audios_dict, f, indent=4)
 
 
-def remove_labeled_audio(audio_path, labeled_audios_dict):
-    """Remove an entry from the labeled audios log."""
+def remove_labeled_audio(audio_path, labeled_audios_dict, labels_data=None):
+    """Remove an entry from the labeled audios log and stored labels."""
+    removed = False
     if audio_path in labeled_audios_dict:
         del labeled_audios_dict[audio_path]
         log_path = CONFIG["LOG_FILE"]
         os.makedirs(os.path.dirname(log_path), exist_ok=True)
         with open(log_path, "w") as f:
             json.dump(labeled_audios_dict, f, indent=4)
-        return True
-    return False
+        removed = True
+
+    if labels_data is not None:
+        removed |= remove_labels_for_audio(audio_path, labels_data)
+
+    return removed


### PR DESCRIPTION
## Summary
- allow storing label segments per audio
- show side file panel with label status filter
- display annotations table while labeling
- enable memory search filtering

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_6862be20c96c832ab4689f8187a94146