### PR TITLE
Improve spectrogram resizing

### DIFF
--- a/audio_labeling_project/audio_processor/spectrogram_generator.py
+++ b/audio_labeling_project/audio_processor/spectrogram_generator.py
@@ -18,7 +18,9 @@ def generate_spectrogram_pixmap(audio_data, samplerate):
     if audio_data is None or len(audio_data) == 0:
         return QPixmap(), None  # Return empty pixmap
 
-    fig, ax = plt.subplots(figsize=(8, 4), dpi=100)
+    # Use a 4:3 aspect ratio so the resulting image scales
+    # nicely between 640x480 and 1280x960 in the UI.
+    fig, ax = plt.subplots(figsize=(6.4, 4.8), dpi=100)
     librosa.display.specshow(
         librosa.amplitude_to_db(np.abs(librosa.stft(audio_data)), ref=np.max),
         sr=samplerate,


### PR DESCRIPTION
## Summary
- ensure spectrogram images use a 4:3 aspect ratio
- constrain spectrogram label size between 640x480 and 1280x960 and resize adaptively
- scale playback lines and annotations with the label size
- refresh spectrogram on window resize

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6863c1a78404832a80b9cf3facebb79a