### PR TITLE
Improve memory and tracking of cut files

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,4 +74,5 @@ Las categorías configuradas actualmente son:
 - El sistema guarda un registro en `memlog/log.json` para no repetir el etiquetado de los mismos archivos.
 - El espectrograma permite seleccionar regiones con el ratón en modo etiquetado.
 - Los cortes se guardan automáticamente en subcarpetas según la categoría seleccionada.
+- La memoria también almacena la ruta de estos cortes en `memlog/labels.json` y se eliminan del disco al borrar su entrada desde la pestaña de memoria.
 

--- a/audio_labeling_project/ui/main_window.py
+++ b/audio_labeling_project/ui/main_window.py
@@ -353,7 +353,11 @@ class MainWindow(QMainWindow):
             ) = generate_spectrogram_pixmap(
                 self.current_audio_data, self.current_samplerate
             )
-            self.annotations = self.labels_data.get(audio_path, [])
+            data = self.labels_data.get(audio_path, {})
+            if isinstance(data, dict):
+                self.annotations = data.get("annotations", [])
+            else:
+                self.annotations = data
             self.refresh_annotations_table()
             self.update_spectrogram()
             self.stop_playback()
@@ -584,6 +588,7 @@ class MainWindow(QMainWindow):
         output_dir = r"D:\Dept. Investigación media\Noches Chimps\Proyectos\DATASET AUDIOS CHIMPS\labeled_cuts"
         create_directory_if_not_exists(output_dir)
 
+        cut_files = []
         for i, (start_time, end_time, category) in enumerate(self.annotations):
             category_dir = os.path.join(output_dir, category)
             create_directory_if_not_exists(category_dir)
@@ -598,10 +603,11 @@ class MainWindow(QMainWindow):
                 end_time,
                 output_path,
             )
+            cut_files.append(output_path)
             self.status_label.setText(f"Saved cut to: {output_path}")
 
         audio_path = self.audio_files[self.current_audio_index]
-        save_labels_for_audio(audio_path, self.annotations, self.labels_data)
+        save_labels_for_audio(audio_path, self.annotations, self.labels_data, cut_files)
         log_labeled_audio(audio_path, self.labeled_audios)
         self.refresh_memory_table()
         self.refresh_file_list()


### PR DESCRIPTION
## Summary
- track generated cut files in `logger.py`
- remove saved cuts when deleting memory entries
- update `MainWindow` to save cut list
- document memory cleanup behavior

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_6863c5d701f4832ab8bc157e16dc510a